### PR TITLE
Adding a time format for string validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Adds support for these formats:
 - objectid
 - date (YYYY-MM-DD)
 - date-time (for example, 2014-05-02T12:59:29+00:00)
+- time (HH:mm or HH:mm:ss, e.g. 23:04:20)
 - email
 
 Simply include the format in your schema:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodeggs-json-schema-validator",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "Good Eggs JSON Schema Validator",
   "author": "Good Eggs <open-source@goodeggs.com>",
   "contributors": [

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -17,6 +17,11 @@ tv4.addFormat 'date', (data) ->
     return null
   return "date, YYYY-MM-DD format, expected"
 
+tv4.addFormat 'time', (data) ->
+  if typeof data is 'string' and /^[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?$/.test(data)
+    return null
+  return "time, HH:mm:ss or HH:mm format, expected"
+
 tv4.addFormat 'email', (data) ->
   # Source: http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
   emailRegex = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/

--- a/test/validator.coffee
+++ b/test/validator.coffee
@@ -33,6 +33,42 @@ describe 'formats', ->
       expect(validator.validate('20141111', schema)).not.to.be.ok
       expect(validator.error).to.have.property 'message', 'Format validation failed (date, YYYY-MM-DD format, expected)'
 
+  describe 'time', ->
+
+    it 'validates valid time with seconds', ->
+      schema = {type: 'string', format: 'time'}
+      expect(validator.validate('23:01:59', schema)).to.be.ok
+
+    it 'validates valid time without seconds', ->
+      schema = {type: 'string', format: 'time'}
+      expect(validator.validate('00:31', schema)).to.be.ok
+
+    it 'throws if invalid sequence of digits', ->
+      schema = {type: 'string', format: 'time'}
+      expect(validator.validate('02:32:11:12', schema)).not.to.be.ok
+      expect(validator.error.message).to.contain 'Format validation failed (time'
+
+    it 'throws if invalid sequence of alphanumeric characters', ->
+      schema = {type: 'string', format: 'time'}
+      expect(validator.validate('ab21:21', schema)).not.to.be.ok
+      expect(validator.error.message).to.contain 'Format validation failed (time'
+
+    it 'throws if too many hours', ->
+      schema = {type: 'string', format: 'time'}
+      expect(validator.validate('30:21', schema)).not.to.be.ok
+      expect(validator.error.message).to.contain 'Format validation failed (time'
+
+    it 'throws if too many minutes', ->
+      schema = {type: 'string', format: 'time'}
+      expect(validator.validate('21:61', schema)).not.to.be.ok
+      expect(validator.error.message).to.contain 'Format validation failed (time'
+
+    it 'throws if too many seconds', ->
+      schema = {type: 'string', format: 'time'}
+      expect(validator.validate('23:59:61', schema)).not.to.be.ok
+      expect(validator.error.message).to.contain 'Format validation failed (time'
+
+
   describe 'email', ->
     it 'validates', ->
       schema = {type: 'string', format: 'email'}


### PR DESCRIPTION
Using the extended ISO8601 time format from: https://en.wikipedia.org/wiki/ISO_8601#Times

Thus far only supporting hours, minutes, and optionally seconds, in 24 hour format. Milliseconds not required.

cc @hurrymaplelad 