### PR TITLE
support null

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -1,35 +1,50 @@
 tv4 = require 'tv4'
 
-tv4.addFormat 'objectid', (data) ->
+allowNull = (data, schema) ->
+  data is null and (schema.type is 'null' or 'null' in schema.type)
+
+tv4.addFormat 'objectid', (data, schema) ->
+  if allowNull(data, schema)
+    return null
   if typeof data is 'string' and /^[a-f\d]{24}$/i.test(data)
     return null
   return "objectid expected"
 
-tv4.addFormat 'date-time', (data) ->
+tv4.addFormat 'date-time', (data, schema) ->
+  if allowNull(data, schema)
+    return null
   # Source: http://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
   dateTimeRegex = /\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+([+-][0-2]\d:[0-5]\d|Z)/
   if typeof data is 'string' and dateTimeRegex.test(data)
     return null
   return "date-time, ISOString format, expected"
 
-tv4.addFormat 'date', (data) ->
+tv4.addFormat 'date', (data, schema) ->
+  if allowNull(data, schema)
+    return null
   if typeof data is 'string' and /\d{4}-[01]\d-[0-3]\d/.test(data)
     return null
   return "date, YYYY-MM-DD format, expected"
 
-tv4.addFormat 'time', (data) ->
+tv4.addFormat 'time', (data, schema) ->
+  if allowNull(data, schema)
+    return null
   if typeof data is 'string' and /^[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?$/.test(data)
     return null
   return "time, HH:mm:ss or HH:mm format, expected"
 
-tv4.addFormat 'email', (data) ->
+tv4.addFormat 'email', (data, schema) ->
+  if allowNull(data, schema)
+    return null
   # Source: http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
   emailRegex = /[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?/
   if typeof data is 'string' and emailRegex.test(data)
     return null
   return "email expected"
 
-tv4.addFormat 'non-negative-integer', (data) ->
+tv4.addFormat 'non-negative-integer', (data, schema) ->
+  if allowNull(data, schema)
+    return null
   if typeof data is 'string' and /^[0-9]+$/.test(data)
     return null
   return "non negative integer expected"

--- a/test/validator.coffee
+++ b/test/validator.coffee
@@ -12,6 +12,15 @@ describe 'formats', ->
       expect(validator.validate('123abc', schema)).not.to.be.ok
       expect(validator.error).to.have.property 'message', 'Format validation failed (objectid expected)'
 
+    describe 'null values', ->
+      it 'throws if it is not an accepted type', ->
+        schema = {type: 'string', format: 'objectid'}
+        expect(validator.validate(null, schema)).not.to.be.ok
+
+      it 'does not check the format if null is an accepted type', ->
+        schema = {type: ['string', 'null'], format: 'objectid'}
+        expect(validator.validate(null, schema)).to.be.ok
+
   describe 'date-time', ->
     it 'validates', ->
       schema = {type: 'string', format: 'date-time'}
@@ -23,6 +32,15 @@ describe 'formats', ->
       expect(validator.validate('2014-11-11', schema)).not.to.be.ok
       expect(validator.error).to.have.property 'message', 'Format validation failed (date-time, ISOString format, expected)'
 
+    describe 'null values', ->
+      it 'throws if it is not an accepted type', ->
+        schema = {type: 'string', format: 'date-time'}
+        expect(validator.validate(null, schema)).not.to.be.ok
+
+      it 'does not check the format if null is an accepted type', ->
+        schema = {type: ['string', 'null'], format: 'date-time'}
+        expect(validator.validate(null, schema)).to.be.ok
+
   describe 'date', ->
     it 'validates', ->
       schema = {type: 'string', format: 'date'}
@@ -33,8 +51,16 @@ describe 'formats', ->
       expect(validator.validate('20141111', schema)).not.to.be.ok
       expect(validator.error).to.have.property 'message', 'Format validation failed (date, YYYY-MM-DD format, expected)'
 
-  describe 'time', ->
+    describe 'null values', ->
+      it 'throws if it is not an accepted type', ->
+        schema = {type: 'string', format: 'date'}
+        expect(validator.validate(null, schema)).not.to.be.ok
 
+      it 'does not check the format if null is an accepted type', ->
+        schema = {type: ['string', 'null'], format: 'date'}
+        expect(validator.validate(null, schema)).to.be.ok
+
+  describe 'time', ->
     it 'validates valid time with seconds', ->
       schema = {type: 'string', format: 'time'}
       expect(validator.validate('23:01:59', schema)).to.be.ok
@@ -68,6 +94,15 @@ describe 'formats', ->
       expect(validator.validate('23:59:61', schema)).not.to.be.ok
       expect(validator.error.message).to.contain 'Format validation failed (time'
 
+    describe 'null values', ->
+      it 'throws if it is not an accepted type', ->
+        schema = {type: 'string', format: 'time'}
+        expect(validator.validate(null, schema)).not.to.be.ok
+
+      it 'does not check the format if null is an accepted type', ->
+        schema = {type: ['string', 'null'], format: 'time'}
+        expect(validator.validate(null, schema)).to.be.ok
+
 
   describe 'email', ->
     it 'validates', ->
@@ -79,6 +114,16 @@ describe 'formats', ->
       expect(validator.validate('goodeggs.com', schema)).not.to.be.ok
       expect(validator.error).to.have.property 'message', 'Format validation failed (email expected)'
 
+    describe 'null values', ->
+      it 'throws if it is not an accepted type', ->
+        schema = {type: 'string', format: 'email'}
+        expect(validator.validate(null, schema)).not.to.be.ok
+
+      it 'does not check the format if null is an accepted type', ->
+        schema = {type: ['string', 'null'], format: 'email'}
+        expect(validator.validate(null, schema)).to.be.ok
+
+
   describe 'integer', ->
     it 'validates', ->
       schema = {type: 'string', format: 'non-negative-integer'}
@@ -88,3 +133,13 @@ describe 'formats', ->
       schema = {type: 'string', format: 'non-negative-integer'}
       expect(validator.validate('12.5', schema)).not.to.be.ok
       expect(validator.error).to.have.property 'message', 'Format validation failed (non negative integer expected)'
+
+    describe 'null values', ->
+      it 'throws if it is not an accepted type', ->
+        schema = {type: 'string', format: 'integer'}
+        expect(validator.validate(null, schema)).not.to.be.ok
+
+      it 'does not check the format if null is an accepted type', ->
+        schema = {type: ['string', 'null'], format: 'integer'}
+        expect(validator.validate(null, schema)).to.be.ok
+


### PR DESCRIPTION
If a schema defines a `format` and accepts *null* values (e.g. `type: ['string', 'null']`), we shouldn't apply the format when null is passed in.