### PR TITLE
Don't overwrite global tv4 formats

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 import tv4 from 'tv4';
 import assert from 'assert';
 
+const clonedTv4 = tv4.freshApi();
 const allowNull = (data, schema) => data === null && (schema.type === 'null' || schema.type.includes('null'));
 
-tv4.addFormat('objectid', (data, schema) => {
+clonedTv4.addFormat('objectid', (data, schema) => {
   if (allowNull(data, schema))
     return null;
   if (typeof data === 'string' && /^[a-f\d]{24}$/i.test(data))
@@ -11,7 +12,7 @@ tv4.addFormat('objectid', (data, schema) => {
   return 'objectid expected';
 });
 
-tv4.addFormat('date-time', (data, schema) => {
+clonedTv4.addFormat('date-time', (data, schema) => {
   if (allowNull(data, schema))
     return null;
   // Source: http://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
@@ -21,7 +22,7 @@ tv4.addFormat('date-time', (data, schema) => {
   return 'date-time, ISOString format, expected';
 });
 
-tv4.addFormat('date', (data, schema) => {
+clonedTv4.addFormat('date', (data, schema) => {
   if (allowNull(data, schema))
     return null;
   if (typeof data === 'string' && /\d{4}-[01]\d-[0-3]\d/.test(data))
@@ -29,7 +30,7 @@ tv4.addFormat('date', (data, schema) => {
   return 'date, YYYY-MM-DD format, expected';
 });
 
-tv4.addFormat('time', (data, schema) => {
+clonedTv4.addFormat('time', (data, schema) => {
   if (allowNull(data, schema))
     return null;
   if (typeof data === 'string' && /^[0-2][0-9]:[0-5][0-9](:[0-5][0-9])?$/.test(data))
@@ -37,7 +38,7 @@ tv4.addFormat('time', (data, schema) => {
   return 'time, HH:mm:ss or HH:mm format, expected';
 });
 
-tv4.addFormat('email', (data, schema) => {
+clonedTv4.addFormat('email', (data, schema) => {
   if (allowNull(data, schema))
     return null;
   // Source: http://stackoverflow.com/questions/46155/validate-email-address-in-javascript
@@ -47,7 +48,7 @@ tv4.addFormat('email', (data, schema) => {
   return 'email expected';
 });
 
-tv4.addFormat('non-negative-integer', (data, schema) => {
+clonedTv4.addFormat('non-negative-integer', (data, schema) => {
   if (allowNull(data, schema))
     return null;
   if (typeof data === 'string' && /^[0-9]+$/.test(data))
@@ -55,12 +56,12 @@ tv4.addFormat('non-negative-integer', (data, schema) => {
   return 'non negative integer expected';
 });
 
-module.exports = tv4;
+module.exports = clonedTv4;
 module.exports.assertValid = function (data, schema, errorMessage, {banUnknownProperties} = {banUnknownProperties: true}) {
   assert(typeof schema === 'object', 'schema must be an object');
   if (errorMessage != null)
     assert(typeof errorMessage === 'string', 'errorMessage must be a string');
-  const {valid, error} = tv4.validateResult(data, schema, null, banUnknownProperties);
+  const {valid, error} = clonedTv4.validateResult(data, schema, null, banUnknownProperties);
   if (!valid) {
     const message = (() => {
       let result = '';

--- a/test/formats.js
+++ b/test/formats.js
@@ -1,4 +1,5 @@
 // @flow
+import tv4 from 'tv4';
 import {describe, it} from 'mocha';
 import {expect} from 'goodeggs-test-helpers/chai';
 
@@ -185,5 +186,13 @@ describe('formats', function () {
         expect(validator.validate(null, schema)).to.be.ok();
       });
     });
+  });
+
+  // regression test https://www.pivotaltracker.com/story/show/154646826
+  it('does not overwrite formats when adding global tv4 formats', function () {
+    tv4.addFormat('date-time', () => 'sad panda');
+    const schema = {type: 'string', format: 'date-time'};
+    const date = new Date().toISOString();
+    expect(validator.validate(date, schema)).to.be.ok();
   });
 });


### PR DESCRIPTION
If we have one instance of tv4, but several instances of `goodeggs-json-schema-validator`, whichever `goodeggs-json-schema-validator` gets loaded last overwrites the global tv4 formats.

For instance, we fixed [the `null` "format" bug](https://github.com/goodeggs/goodeggs-json-schema-validator/pull/5) a while ago, but the broken version often overwrites the fixed version.

Instead, use `tv4.freshApi()` so that we don't modify the global tv4 instance.

[#154646826]

Thank you @serhalp for your help investigating!