### PR TITLE
stop testing against node 6; test node 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ dist: trusty
 
 language: node_js
 node_js:
+- 10
 - 8
-- 6


### PR DESCRIPTION
Node 6 is now out of maintenance. Node 10 is active. Updating what we test against in travis.