### PR TITLE
Add ValidationError subclass with custom attributes

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,8 +1,26 @@
 // @flow
-declare module.exports: {
-  assertValid (data: any, schema: Object, message?: ?string, options?: {banUnknownProperties?: boolean}): void;
-  validate (data: any, schema: Object): boolean;
-  validateResult (data: any, schema: Object): {valid: boolean, error: Error, missing: any[]};
-  validateMultiple (data: any, schema: Object): {valid: boolean, errors: Array<Error>, missing: any[]};
-  error: Error;
+class ValidationError extends Error {
+  subErrors: Array<ValidationError>;
+  params: string;
+  dataPath: string;
+  schemaPath: string;
 }
+
+declare module.exports: {
+  assertValid(
+    data: any,
+    schema: Object,
+    message?: ?string,
+    options?: { banUnknownProperties?: boolean }
+  ): void,
+  validate(data: any, schema: Object): boolean,
+  validateResult(
+    data: any,
+    schema: Object
+  ): { valid: boolean, error: ValidationError, missing: any[] },
+  validateMultiple(
+    data: any,
+    schema: Object
+  ): { valid: boolean, errors: Array<ValidationError>, missing: any[] },
+  error: ValidationError
+};


### PR DESCRIPTION
## Background
As now we're validating catalog-api contracts with `anyOf` fields, it was necessary to create a type of `ValidationError` that handles with custom attributes.

## Changes

Added class `ValidationError` to extend `Error` with custom attributes.



[#169085195]
:pear: w/ @serhalp 
FYI @goodeggs/pim 
