### PR TITLE
chore: add pipeline.yml

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ plugin-node-cache: &plugin-node-cache
 
 plugin-secrets: &plugin-secrets
   secrets:
-    NPM_TOKEN: ENCRYPTED_SECRET_STRING
+    NPM_TOKEN: vLVSsOFBFmk/_hD_Keyzv56PaGwq11j6oQ/feHGOYCvOyXfWzX9qR94eLTC0yTMyspx-4YGk1DlA4zzYklb
 
 plugins: &plugins
   - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.1.1: *plugin-node-cache

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -21,7 +21,7 @@ steps:
   - label: 'Publish'
     if: build.tag != null
     command:
-      - export PATH="/tmp/ci-tools:./node_modules/.bin:$PATH"
+      - export PATH="./node_modules/.bin:$PATH"
       - yarn publish
     concurrency: 1
     concurrency_group: 'goodeggs-json-schema-validator/publish'

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -3,7 +3,7 @@ plugin-node-cache: &plugin-node-cache
 
 plugin-secrets: &plugin-secrets
   secrets:
-    NPM_TOKEN: vLVSsOFBFmk/_hD_Keyzv56PaGwq11j6oQ/feHGOYCvOyXfWzX9qR94eLTC0yTMyspx-4YGk1DlA4zzYklb
+    NPM_TOKEN: 7KuBofGb-Uo/GPCxGBsfNC-t8HmUYn7xEQ/QIuqj3veHdDor29EXeluMiXBOAKL_57sqg1Z2K3oYNC52t_U
 
 plugins: &plugins
   - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.1.1: *plugin-node-cache

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,28 @@
+plugin-node-cache: &plugin-node-cache
+  cache_node: true
+
+plugin-secrets: &plugin-secrets
+  secrets:
+    NPM_TOKEN: ENCRYPTED_SECRET_STRING
+
+plugins: &plugins
+  - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.1.1: *plugin-node-cache
+  - ssh://git@github.com/goodeggs/goodeggs-core-buildkite-plugin#v0.1.1: *plugin-secrets
+
+steps:
+  - label: 'Install'
+    command: NODE_ENV=development yarn install --frozen-lockfile
+    plugins: *plugins
+  - wait
+  - label: 'Test'
+    command: yarn test
+    plugins: *plugins
+  - wait
+  - label: 'Publish'
+    if: build.tag != null
+    command:
+      - export PATH="/tmp/ci-tools:./node_modules/.bin:$PATH"
+      - yarn publish
+    concurrency: 1
+    concurrency_group: 'goodeggs-json-schema-validator/publish'
+    plugins: *plugins

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,1 @@
-always-auth=true
-registry=https://npm.goodeggs.com
-//npm.goodeggs.com/:_authToken=${NPM_TOKEN}
+registry = https://registry.npmjs.org/

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 registry = https://registry.npmjs.org/
+//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
-registry=https://registry.yarnpkg.com
+always-auth=true
+registry=https://npm.goodeggs.com
+//npm.goodeggs.com/:_authToken=${NPM_TOKEN}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: required
-dist: trusty
-
-language: node_js
-node_js:
-  - 14

--- a/README.md
+++ b/README.md
@@ -46,3 +46,14 @@ $ npm test
 [license-link]: LICENSE.md
 [hiring-badge]: https://img.shields.io/badge/we're_hiring-yes-brightgreen.svg?style=flat-square
 [hiring-link]: http://goodeggs.jobscore.com/?detail=Open+Source&sid=161
+
+## Releasing
+
+To release a new version of this module, use yarn to bump the version
+in `package.json` and create a git tag, then push. This will automatically
+get published to the NPM registry via CI.
+
+```sh
+yarn version --new-version=<major|minor|patch|premajor|preminor|prepatch>
+git push --follow-tags
+```


### PR DESCRIPTION
## Background

After porting goodeggs-json-schema-validator I noticed that the libray didn't has a script for publish and deploy at travis.yml.
Since Good Eggs is moving all applications to buildkite, Rishabh asked to move goodeggs-json-schema-validator too.

## Changes

- Add script for buildkite