### PR TITLE
Fix build script to allow publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
   "homepage": "https://github.com/goodeggs/goodeggs-json-schema-validator",
   "bugs": "https://github.com/goodeggs/goodeggs-json-schema-validator/issues",
   "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "typescript": "^4.9.5"
   },
   "scripts": {
-    "build": "yarn run build:clean && babel --extensions=.ts,.js,.jsx,.tsx src -d lib && cp src/index.js lib && yarn run build:types",
+    "build": "yarn run build:clean && babel --extensions=.ts,.js,.jsx,.tsx src -d lib && yarn run build:types",
     "build:clean": "rm -rf lib",
     "build:types": "tsc --project tsconfig.declarations.json",
     "prepublishOnly": "yarn run build",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodeggs-json-schema-validator",
-  "version": "6.0.2",
+  "version": "6.0.3",
   "description": "Good Eggs JSON Schema Validator",
   "author": "Good Eggs <open-source@goodeggs.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodeggs-json-schema-validator",
-  "version": "6.0.1",
+  "version": "6.0.2",
   "description": "Good Eggs JSON Schema Validator",
   "author": "Good Eggs <open-source@goodeggs.com>",
   "contributors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "goodeggs-json-schema-validator",
-  "version": "6.0.3",
+  "version": "6.0.4",
   "description": "Good Eggs JSON Schema Validator",
   "author": "Good Eggs <open-source@goodeggs.com>",
   "contributors": [


### PR DESCRIPTION
## Background
When updating goodeggs-json-schema-validator in goodeggs-domain-events-contract-test-helper , I noticed that the latest version 6.0.1 wasn't published at npm. 

The Publish script at buildkite was failing because the build script at the library had an unnecessary command.

 Buildkite error before changes:
![Screen Shot 2023-05-26 at 1 29 39 PM](https://github.com/goodeggs/goodeggs-json-schema-validator/assets/95692939/e71fd8dd-4b12-4afb-8e82-4261adab53db)

Local test after changes:
![Screen Shot 2023-05-26 at 1 47 28 PM](https://github.com/goodeggs/goodeggs-json-schema-validator/assets/95692939/a9ceb0ac-a2ec-4fcc-a4a1-313c0e9dc81a)


## Changes
- Alter build script

## Next step
- Run yarn patch to publish the library